### PR TITLE
Update init sequence for Windows types.

### DIFF
--- a/audioipc/src/lib.rs
+++ b/audioipc/src/lib.rs
@@ -52,6 +52,13 @@ use std::path::PathBuf;
 #[cfg(not(target_os = "linux"))]
 const MSG_CMSG_CLOEXEC: libc::c_int = 0;
 
+// This must match the definition of
+// ipc::FileDescriptor::PlatformHandleType in Gecko.
+#[cfg(target_os = "windows")]
+pub type PlatformHandleType = *mut libc::c_void;
+#[cfg(not(target_os = "windows"))]
+pub type PlatformHandleType = libc::c_int;
+
 // Extend sys::os::unix::net::UnixStream to support sending and receiving a single file desc.
 // We can extend UnixStream by using traits, eliminating the need to introduce a new wrapped
 // UnixStream type.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -20,6 +20,7 @@ mod send_recv;
 mod context;
 mod stream;
 
+use audioipc::PlatformHandleType;
 use context::ClientContext;
 use cubeb_backend::{capi, ffi};
 use std::os::raw::{c_char, c_int};
@@ -34,7 +35,7 @@ thread_local!(static CPUPOOL_INIT_PARAMS: InitParamsTls = std::cell::RefCell::ne
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 pub struct AudioIpcInitParams {
-    pub server_connection: c_int,
+    pub server_connection: PlatformHandleType,
     pub pool_size: usize,
     pub stack_size: usize,
     pub thread_create_callback: Option<extern "C" fn(*const ::std::os::raw::c_char)>,

--- a/gecko/0001-Windows-fix-init.patch
+++ b/gecko/0001-Windows-fix-init.patch
@@ -30,7 +30,7 @@ diff --git a/dom/media/CubebUtils.cpp b/dom/media/CubebUtils.cpp
  // These functions are provided by audioipc-server crate
  extern void* audioipc_server_start();
  extern mozilla::ipc::FileDescriptor::PlatformHandleType audioipc_server_new_client(void*);
-@@ -398,19 +400,24 @@ void InitAudioIPCConnection()
+@@ -398,19 +400,29 @@ void InitAudioIPCConnection()
                  });
  }
  #endif
@@ -40,9 +40,14 @@ diff --git a/dom/media/CubebUtils.cpp b/dom/media/CubebUtils.cpp
  #ifdef MOZ_CUBEB_REMOTING
    MOZ_ASSERT(sServerHandle);
 -  int rawFD = audioipc_server_new_client(sServerHandle);
-+  mozilla::ipc::FileDescriptor::PlatformHandleType rawFD = audioipc_server_new_client(sServerHandle);
++  ipc::FileDescriptor::PlatformHandleType rawFD = audioipc_server_new_client(sServerHandle);
    ipc::FileDescriptor fd(rawFD);
-+  // TODO: Find cleaner cross-platform way to do this.
++  if (!fd.IsValid()) {
++    MOZ_LOG(gCubebLog, LogLevel::Error, ("audioipc_server_new_client failed"));
++    return ipc::FileDescriptor();
++  }
++  // Close rawFD since FileDescriptor's ctor cloned it.
++  // TODO: Find cleaner cross-platform way to close rawFD.
 +#ifdef XP_WIN
 +  CloseHandle(rawFD);
 +#else

--- a/gecko/0001-Windows-fix-init.patch
+++ b/gecko/0001-Windows-fix-init.patch
@@ -1,0 +1,81 @@
+diff --git a/dom/media/CubebUtils.cpp b/dom/media/CubebUtils.cpp
+--- a/dom/media/CubebUtils.cpp
++++ b/dom/media/CubebUtils.cpp
+@@ -45,24 +45,26 @@
+ // Hidden pref used by tests to force failure to obtain cubeb context
+ #define PREF_CUBEB_FORCE_NULL_CONTEXT "media.cubeb.force_null_context"
+ // Hidden pref to disable BMO 1427011 experiment; can be removed once proven.
+ #define PREF_CUBEB_DISABLE_DEVICE_SWITCHING "media.cubeb.disable_device_switching"
+ #define PREF_CUBEB_SANDBOX "media.cubeb.sandbox"
+ #define PREF_AUDIOIPC_POOL_SIZE "media.audioipc.pool_size"
+ #define PREF_AUDIOIPC_STACK_SIZE "media.audioipc.stack_size"
+ 
+-#if (defined(XP_LINUX) && !defined(MOZ_WIDGET_ANDROID)) || defined(XP_MACOSX)
++#if (defined(XP_LINUX) && !defined(MOZ_WIDGET_ANDROID)) || defined(XP_MACOSX) || defined(XP_WIN)
+ #define MOZ_CUBEB_REMOTING
+ #endif
+ 
+ extern "C" {
+ 
++// This must match AudioIpcInitParams in media/audioipc/client/src/lib.rs.
++// TODO: Generate this from the Rust definition rather than duplicating it.
+ struct AudioIpcInitParams {
+-  int mServerConnection;
++  mozilla::ipc::FileDescriptor::PlatformHandleType mServerConnection;
+   size_t mPoolSize;
+   size_t mStackSize;
+   void (*mThreadCreateCallback)(const char*);
+ };
+ 
+ // These functions are provided by audioipc-server crate
+ extern void* audioipc_server_start();
+ extern mozilla::ipc::FileDescriptor::PlatformHandleType audioipc_server_new_client(void*);
+@@ -398,19 +400,24 @@ void InitAudioIPCConnection()
+                 });
+ }
+ #endif
+ 
+ ipc::FileDescriptor CreateAudioIPCConnection()
+ {
+ #ifdef MOZ_CUBEB_REMOTING
+   MOZ_ASSERT(sServerHandle);
+-  int rawFD = audioipc_server_new_client(sServerHandle);
++  mozilla::ipc::FileDescriptor::PlatformHandleType rawFD = audioipc_server_new_client(sServerHandle);
+   ipc::FileDescriptor fd(rawFD);
++  // TODO: Find cleaner cross-platform way to do this.
++#ifdef XP_WIN
++  CloseHandle(rawFD);
++#else
+   close(rawFD);
++#endif
+   return fd;
+ #else
+   return ipc::FileDescriptor();
+ #endif
+ }
+ 
+ cubeb* GetCubebContextUnlocked()
+ {
+diff --git a/toolkit/library/rust/gkrust-features.mozbuild b/toolkit/library/rust/gkrust-features.mozbuild
+--- a/toolkit/library/rust/gkrust-features.mozbuild
++++ b/toolkit/library/rust/gkrust-features.mozbuild
+@@ -13,15 +13,16 @@ if CONFIG['MOZ_BUILD_WEBRENDER']:
+     gkrust_features += ['quantum_render']
+ 
+ if CONFIG['MOZ_PULSEAUDIO']:
+     gkrust_features += ['cubeb_pulse_rust']
+ 
+ if CONFIG['MOZ_RUST_SIMD']:
+     gkrust_features += ['simd-accel']
+ 
+-# This feature is only supported on Linux and macOS, and this check needs to
+-# match MOZ_CUBEB_REMOTING in CubebUtils.cpp.
+-if (CONFIG['OS_ARCH'] == 'Linux' and CONFIG['OS_TARGET'] != 'Android') or CONFIG['OS_ARCH'] == 'Darwin':
++# This feature is only supported on Linux, macOS, and Windows, and this
++# check needs to match MOZ_CUBEB_REMOTING in CubebUtils.cpp.
++if ((CONFIG['OS_ARCH'] == 'Linux' and CONFIG['OS_TARGET'] != 'Android') or
++    CONFIG['OS_ARCH'] == 'Darwin' or CONFIG['OS_ARCH'] == 'WINNT'):
+     gkrust_features += ['cubeb-remoting']
+ 
+ if CONFIG['MOZ_MEMORY']:
+     gkrust_features += ['moz_memory']

--- a/ipctest/src/client.rs
+++ b/ipctest/src/client.rs
@@ -153,6 +153,7 @@ pub fn client_test(fd: c_int) -> Result<()> {
         server_connection: fd,
         pool_size: 1,
         stack_size: 64 * 1024,
+        thread_create_callback: None,
     };
     if unsafe { audioipc_client::audioipc_client_init(&mut c, context_name.as_ptr(), &init_params) }
         < 0

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -22,6 +22,7 @@ use audioipc::messages::{CallbackReq, CallbackResp, ClientMessage, Device, Devic
                          ServerMessage, StreamCreate, StreamInitParams, StreamParams};
 use audioipc::rpc;
 use audioipc::shm::{SharedMemReader, SharedMemWriter};
+use audioipc::PlatformHandleType;
 use cubeb::ffi;
 use futures::future::{self, FutureResult};
 use futures::sync::oneshot;
@@ -487,7 +488,7 @@ pub extern "C" fn audioipc_server_start() -> *mut c_void {
 }
 
 #[no_mangle]
-pub extern "C" fn audioipc_server_new_client(p: *mut c_void) -> libc::c_int {
+pub extern "C" fn audioipc_server_new_client(p: *mut c_void) -> PlatformHandleType {
     let (wait_tx, wait_rx) = oneshot::channel();
     let wrapper: &ServerWrapper = unsafe { &*(p as *mut _) };
 


### PR DESCRIPTION
Introduce PlatformHandleType typedef in audioipc to match Gecko's
FileDescriptor.

Switch AudioIpcInitParams and audioipc_server_new_client file descriptor types
from int to PlatformHandleType to prep for Windows port changes.