### PR TITLE
Disable audio_thread_priority default features

### DIFF
--- a/audioipc/Cargo.toml
+++ b/audioipc/Cargo.toml
@@ -29,6 +29,7 @@ arrayvec = "0.7"
 
 [target.'cfg(target_os = "linux")'.dependencies.audio_thread_priority]
 version = "0.26.1"
+default-features = false
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["combaseapi", "memoryapi", "objbase"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -16,3 +16,4 @@ log = "0.4"
 
 [dependencies.audio_thread_priority]
 version = "0.26.1"
+default-features = false

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,3 +22,4 @@ default-features = false
 
 [dependencies.audio_thread_priority]
 version = "0.26.1"
+default-features = false


### PR DESCRIPTION
with_dbus is supposed to be optional in gecko, but in practice, the
audio_thread_priority defaults force it on.